### PR TITLE
feat: vscode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ rollback:
 	sudo nixos-rebuild switch --rollback --max-jobs ${MAX_JOBS}
 
 check:
-	nix flake check --max-jobs ${MAX_JOBS}
+	nix flake check --show-trace --max-jobs ${MAX_JOBS}

--- a/flake.lock
+++ b/flake.lock
@@ -1,31 +1,8 @@
 {
   "nodes": {
-    "alejandra": {
-      "inputs": {
-        "fenix": "fenix",
-        "flakeCompat": "flakeCompat",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1660592437,
-        "narHash": "sha256-xFumnivtVwu5fFBOrTxrv6fv3geHKF04RGP23EsDVaI=",
-        "owner": "kamadorueda",
-        "repo": "alejandra",
-        "rev": "e7eac49074b70814b542fee987af2987dd0520b5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kamadorueda",
-        "ref": "3.0.0",
-        "repo": "alejandra",
-        "type": "github"
-      }
-    },
     "devshell": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixvim",
           "nixpkgs"
@@ -45,29 +22,23 @@
         "type": "github"
       }
     },
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "alejandra",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
+    "flake-compat": {
+      "flake": false,
       "locked": {
-        "lastModified": 1657607339,
-        "narHash": "sha256-HaqoAwlbVVZH2n4P3jN2FFPMpVuhxDy1poNOR7kzODc=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "b814c83d9e6aa5a28d0cf356ecfdafb2505ad37d",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
+        "owner": "edolstra",
+        "repo": "flake-compat",
         "type": "github"
       }
     },
-    "flake-compat": {
+    "flake-compat_2": {
       "locked": {
         "lastModified": 1696426674,
         "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
@@ -81,7 +52,7 @@
         "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
       }
     },
-    "flake-compat_2": {
+    "flake-compat_3": {
       "flake": false,
       "locked": {
         "lastModified": 1696426674,
@@ -123,24 +94,6 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
         "lastModified": 1710146030,
         "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
@@ -154,19 +107,39 @@
         "type": "github"
       }
     },
-    "flakeCompat": {
-      "flake": false,
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -194,9 +167,7 @@
     },
     "home-manager": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1711915616,
@@ -254,7 +225,59 @@
         "type": "github"
       }
     },
+    "nix-vscode-extensions": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1712970366,
+        "narHash": "sha256-QDzaNEbyhnREXw4+W8nGgnuHMUucBes+hCB2Dr/NRh0=",
+        "owner": "nix-community",
+        "repo": "nix-vscode-extensions",
+        "rev": "07d646a3a23c7bbacec58baec7e9e5d80a5d36a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-vscode-extensions",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1712791164,
+        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1712222121,
+        "narHash": "sha256-8f3glF4uwsPlDvaKDRgXD9xGe4YoCH4jA8ICxy/NbCo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "23ff7d9dc4f3d553939e7bfe0d2667198f993536",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1711703276,
         "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
@@ -270,16 +293,30 @@
         "type": "github"
       }
     },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1712791164,
+        "narHash": "sha256-3sbWO1mbpWsLepZGbWaMovSO7ndZeFqDSdX0hZ9nVyw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1042fd8b148a9105f3c0aca3a6177fd1d9360ba5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixvim": {
       "inputs": {
         "devshell": "devshell",
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager_2",
         "nix-darwin": "nix-darwin",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs_4",
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
@@ -298,8 +335,8 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_2",
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_3",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixvim",
@@ -326,27 +363,10 @@
     },
     "root": {
       "inputs": {
-        "alejandra": "alejandra",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs",
+        "nix-vscode-extensions": "nix-vscode-extensions",
+        "nixpkgs": "nixpkgs_3",
         "nixvim": "nixvim"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1657557289,
-        "narHash": "sha256-PRW+nUwuqNTRAEa83SfX+7g+g8nQ+2MMbasQ9nt6+UM=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "caf23f29144b371035b864a1017dbc32573ad56d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
       }
     },
     "systems": {
@@ -365,6 +385,21 @@
       }
     },
     "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -3,21 +3,9 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-
-    home-manager = {
-      url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    alejandra = {
-      url = "github:kamadorueda/alejandra/3.0.0";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    nixvim = {
-      url = "github:nix-community/nixvim";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    home-manager.url = "github:nix-community/home-manager";
+    nixvim.url = "github:nix-community/nixvim";
+    nix-vscode-extensions.url = "github:nix-community/nix-vscode-extensions";
   };
 
   outputs = {
@@ -25,9 +13,11 @@
     nixpkgs,
     home-manager,
     nixvim,
+    nix-vscode-extensions,
     ...
   } @ inputs: let
     system = "x86_64-linux";
+
     pkgs = nixpkgs.legacyPackages.${system};
   in {
     nixosConfigurations = {
@@ -43,6 +33,7 @@
             home-manager = {
               useGlobalPkgs = true;
               useUserPackages = true;
+              extraSpecialArgs = {inherit inputs;};
               users.aaron = import ./home;
             };
           }

--- a/home/default.nix
+++ b/home/default.nix
@@ -44,7 +44,6 @@ in {
     # General
     google-chrome
     firefox
-    kitty
     spotify
 
     slack
@@ -55,16 +54,14 @@ in {
 
     # Productivity
     obsidian
-    vscode
     virtualbox
+    jq
 
     # Utilities
     pavucontrol # Audio control
     cinnamon.nemo # File manager
     grimblast # Screen capture
-    wf-recorder # Screen recording
     mpv # Media playback
-    cliphist # Clipboard manager
     davinci-resolve
 
     # Scripts

--- a/home/packages/default.nix
+++ b/home/packages/default.nix
@@ -19,5 +19,6 @@
     ./avizo.nix
     ./easyeffects.nix
     ./foot.nix
+    ./vscode.nix
   ];
 }

--- a/home/packages/vscode.nix
+++ b/home/packages/vscode.nix
@@ -1,0 +1,218 @@
+{
+  config,
+  pkgs,
+  lib,
+  inputs,
+  ...
+}: let
+  extensions = inputs.nix-vscode-extensions.extensions.${pkgs.system};
+
+  inherit (pkgs.vscode-utils) extensionFromVscodeMarketplace;
+
+  aaron-pierce-nodash = extensionFromVscodeMarketplace {
+    name = "nodash";
+    publisher = "aaron-pierce";
+    version = "1.2.0";
+    sha256 = "+STw416hjpxz/gL0JTpmItueqUmMWkYZM7I1XCisLPc=";
+  };
+in {
+  programs.vscode = {
+    enable = true;
+
+    # VSCode will update alongside everything else in the flake
+    enableUpdateCheck = false;
+    enableExtensionUpdateCheck = false;
+
+    extensions = with inputs.nix-vscode-extensions.extensions.${pkgs.system}.vscode-marketplace; [
+      aaron-pierce-nodash
+
+      astro-build.astro-vscode
+      asvetliakov.vscode-neovim
+      bbenoist.nix
+      bradlc.vscode-tailwindcss
+      brennondenny.vsc-jetbrains-icons-enhanced
+      catppuccin.catppuccin-vsc
+      catppuccin.catppuccin-vsc-icons
+      chadalen.vscode-jetbrains-icon-theme
+      codezombiech.gitignore
+      dbaeumer.vscode-eslint
+      esbenp.prettier-vscode
+      firsttris.vscode-jest-runner
+      isudox.vscode-jetbrains-keybindings
+      jnoortheen.nix-ide
+      kamadorueda.alejandra
+      mgmcdermott.vscode-language-babel
+      ms-python.debugpy
+      ms-python.python
+      ms-python.vscode-pylance
+      ms-vscode.vscode-typescript-next
+      ms-vsliveshare.vsliveshare
+      streetsidesoftware.code-spell-checker
+      usernamehw.errorlens
+      wayou.vscode-todo-highlight
+      yoavbls.pretty-ts-errors
+    ];
+
+    languageSnippets = {
+      nix = {
+        new-file = {
+          prefix = "new";
+          body = [
+            "{"
+            "  config,"
+            "  pkgs,"
+            "  lib,"
+            "  inputs,"
+            "  ..."
+            "}: {"
+            "  $0"
+            "}"
+          ];
+        };
+        multiline-string = {
+          prefix = "ms";
+          body = [
+            "''"
+            "  $0"
+            "'';"
+          ];
+        };
+      };
+    };
+
+    userSettings = {
+      # Prevent VSCode from opening parent folders, used because we deal in monorepos.
+      "git.openRepositoryInParentFolders" = "always";
+
+      # Auto save
+      "files.autoSave" = "afterDelay";
+
+      # Automatically update import locations when moving TS/JS files
+      "typescript.updateImportsOnFileMove.enabled" = "always";
+      "javascript.updateImportsOnFileMove.enabled" = "always";
+
+      # Language specific features
+      "[javascript,javascriptreact,typescript,typescriptreact]" = {
+        "editor.defaultFormatter" = "esbenp.prettier-vscode";
+      };
+
+      "[css]" = {
+        "editor.defaultFormatter" = "vscode.css-language-features";
+      };
+
+      "[nix]" = {
+        "editor.defaultFormatter" = "kamadorueda.alejandra";
+        "editor.formatOnPaste" = true;
+        "editor.formatOnSave" = true;
+        "editor.formatOnType" = false;
+      };
+
+      # Settings for nixd and NixIDE
+      "nix.enableLanguageServer" = true;
+      "nix.serverPath" = "nixd";
+      "nix.serverSettings" = {
+        "nixd" = {
+          "eval" = {};
+          "formatting" = {
+            "command" = "nixpkgs-fmt";
+          };
+          "options" = {
+            "enable" = true;
+            "target" = {
+              # tweak arguments here
+              "args" = [];
+              # NixOS options
+              "installable" = "<flakeref>#nixosConfigurations.<name>.options";
+
+              # Home-manager options
+              # "installable" = "<flakeref>#homeConfigurations.<name>.options";
+            };
+          };
+        };
+      };
+
+      # Location of the Nix formatter
+      "alejandra.program" = "alejandra";
+
+      # Auto formatting and linting on save.
+      "editor.formatOnSave" = true;
+      "eslint.format.enable" = true;
+      "editor.codeActionsOnSave" = {
+        "source.organizeImports" = "never";
+        "source.addMissingImports" = "explicit";
+        "source.fixAll.eslint" = "explicit";
+        "eslint.applyAllFixes" = "explicit";
+      };
+      "eslint.workingDirectories" = [
+        {
+          "mode" = "auto";
+        }
+      ];
+
+      # Use Vim, can't ever hide line numbers
+      "zenMode.hideLineNumbers" = false;
+
+      # Set the icon theme
+      "workbench.iconTheme" = "catppuccin-latte";
+
+      # Show scrollbars (like JetBrains)
+      "editor.scrollbar.verticalScrollbarSize" = 10;
+      "editor.scrollbar.horizontalScrollbarSize" = 10;
+      "editor.scrollbar.vertical" = "visible";
+      "editor.scrollbar.horizontal" = "visible";
+
+      # Use Sticky Scroll
+      "editor.stickyScroll.enabled" = true;
+
+      # Fonts (JetBrains font)
+      "editor.fontFamily" = "'JetBrainsMono Nerd Font Mono', 'Font Awesome 6 Brands', 'Font Awesome 6 Free', 'Font Awesome 6 Free Solid', monospace";
+      "editor.fontLigatures" = false;
+      "editor.fontSize" = 14;
+      "editor.fontWeight" = "350";
+      "editor.letterSpacing" = -0.2;
+      "editor.lineHeight" = 1.45;
+
+      # Other editor configs
+      "editor.tabSize" = 2;
+      "editor.lineNumbers" = "relative";
+
+      # Disable indentation lines (because they look bad)
+      "editor.guides.indentation" = false;
+
+      # Indent out the menu items (like JetBrains)
+      "workbench.tree.indent" = 12;
+      "workbench.colorTheme" = "Catppuccin Latte";
+      "workbench.startupEditor" = "none";
+
+      "vscode-neovim.neovimExecutablePaths.darwin" = "/opt/homebrew/bin/nvim";
+      "vscode-neovim.neovimExecutablePaths.linux" = "/run/current-system/sw/bin/nvim";
+
+      "extensions.experimental.affinity" = {
+        "asvetliakov.vscode-neovim" = 1;
+      };
+
+      # Spell checker custom words
+      "cSpell.userWords" = ["asvetliakov" "Catppuccin" "dbaeumer" "esbenp" "flakeref" "kamadorueda" "neovim" "nixd" "nixos" "nixpkgs" "nvim" "scrollback" "scrollbars"];
+
+      # Do not optimize for screen readers
+      "editor.accessibilitySupport" = "off";
+
+      # Prefer non-relative imports
+      "javascript.preferences.importModuleSpecifier" = "non-relative";
+      "typescript.preferences.importModuleSpecifier" = "non-relative";
+
+      # I live on the edge, man
+      "security.workspace.trust.enabled" = false;
+      "security.workspace.trust.untrustedFiles" = "open";
+      "explorer.confirmDragAndDrop" = false;
+      "explorer.confirmDelete" = false;
+
+      # Give me more lines in my terminal
+      "terminal.integrated.scrollback" = 10000;
+      "editor.minimap.enabled" = false;
+      "[json]" = {
+        "editor.defaultFormatter" = "esbenp.prettier-vscode";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Manages the local VSCode install using Nix (rather than imperatively, as it is now)

Questions to answer:
- [x] How do you build a VSCode extension which isn't found in nixpkgs? mkDerivation how?

```nix
let
  inherit (pkgs.vscode-utils) extensionFromVscodeMarketplace;

  aaron-pierce-nodash = extensionFromVscodeMarketplace {
    name = "nodash";
    publisher = "aaron-pierce";
    version = "1.2.0";
    sha256 = "+STw416hjpxz/gL0JTpmItueqUmMWkYZM7I1XCisLPc=";
  };
in
```

- [ ] Would this be managed similarly on nix-darwin?