### PR TITLE
Simplify git-tree and fix work-config glob

### DIFF
--- a/modules/git/default.nix
+++ b/modules/git/default.nix
@@ -103,38 +103,30 @@
           BRANCH="$1"
           BASE="''${2:-HEAD}"
 
-          MAIN_WORKTREE="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
-          TREE_PATH="$(dirname "$MAIN_WORKTREE")/$(basename "$MAIN_WORKTREE")--trees/$BRANCH"
+          # the main worktree is always the first entry in `git worktree list`
+          MAIN="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
+          TREE="$MAIN--$BRANCH"
 
-          # reuse the existing worktree for this branch if there is one
-          EXISTING="$(git worktree list --porcelain | awk -v ref="refs/heads/$BRANCH" '
-            /^worktree / { wt = substr($0, 10) }
-            $0 == "branch " ref { print wt }
-          ')"
+          if [ ! -d "$TREE" ]; then
+            if git show-ref --verify --quiet "refs/heads/$BRANCH" ||
+               git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+              git worktree add "$TREE" "$BRANCH" 1>&2
+            else
+              git worktree add -b "$BRANCH" "$TREE" "$BASE" 1>&2
+            fi
 
-          if [ -n "$EXISTING" ]; then
-            echo "$EXISTING"
-            exit 0
+            # copy gitignored .env files over from the main worktree; --directory
+            # collapses ignored directories (node_modules etc) into a single entry
+            # ending in /, which the loop skips rather than copying from inside
+            git -C "$MAIN" ls-files -z --others --ignored --exclude-standard --directory -- ':(glob)**/.env*' |
+              while IFS= read -r -d "" FILE; do
+                case "$FILE" in */) continue ;; esac
+                mkdir -p "$TREE/$(dirname "$FILE")"
+                cp "$MAIN/$FILE" "$TREE/$FILE"
+              done
           fi
 
-          if git show-ref --verify --quiet "refs/heads/$BRANCH" ||
-             git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
-            git worktree add "$TREE_PATH" "$BRANCH" 1>&2
-          else
-            git worktree add -b "$BRANCH" "$TREE_PATH" "$BASE" 1>&2
-          fi
-
-          # carry gitignored env files over from the main worktree,
-          # collapsing ignored directories (node_modules etc) so we never copy from inside them
-          git -C "$MAIN_WORKTREE" ls-files --others --ignored --exclude-standard --directory -z \
-            -- ':(glob).env*' ':(glob)**/.env*' |
-            while IFS= read -r -d "" FILE; do
-              case "$FILE" in */) continue ;; esac
-              mkdir -p "$TREE_PATH/$(dirname "$FILE")"
-              cp "$MAIN_WORKTREE/$FILE" "$TREE_PATH/$FILE"
-            done
-
-          echo "$TREE_PATH"
+          echo "$TREE"
         '';
       };
 
@@ -233,22 +225,9 @@
 
       includes = [
         {
-          condition = "gitdir:~/workspace/praxhub/";
-          path = "~/.config/git/work-config";
-        }
-
-        {
-          condition = "gitdir:~/workspace/praxhub-web/";
-          path = "~/.config/git/work-config";
-        }
-
-        {
-          condition = "gitdir:~/workspace/praxhub-web-stress-test/";
-          path = "~/.config/git/work-config";
-        }
-
-        {
-          condition = "gitdir:~/workspace/praxhub-test/";
+          # trailing slash is required: git turns "praxhub*/" into "praxhub*/**",
+          # which also matches the gitdirs of linked worktrees (main/.git/worktrees/x)
+          condition = "gitdir:~/workspace/praxhub*/";
           path = "~/.config/git/work-config";
         }
       ];


### PR DESCRIPTION
Simplifies `git-tree` down to its core contract and fixes the consolidated `includeIf` glob.

## git-tree

The worktree for `<branch>` now lives at one fixed sibling path: `<main-repo>--<branch>`. The script is a single conditional:

- directory exists → print it
- otherwise → `git worktree add` (reusing a local or remote branch if one exists, else `-b <branch> <base>`, base defaulting to `HEAD`), copy gitignored `.env*` files over, print it

This replaces the awk scan over `git worktree list --porcelain` with `[ -d $TREE ]` — since the path is deterministic, existence of the directory is the whole check. Also drops the `--trees/` nesting level and the redundant root-level pathspec (`:(glob)**/.env*` matches `.env` at the root too, verified on git 2.55).

Plain `git worktree add` alone can't replace the script: it fails when the branch is already checked out elsewhere and has no way to print an existing worktree's path.

## Work config fix

The uncommitted consolidation to `gitdir:~/workspace/praxhub*` silently matches **nothing** — a lone `*` doesn't cross path components, so it can't reach the `/.git` suffix of the gitdir. The working form is `gitdir:~/workspace/praxhub*/`, which git expands to `praxhub*/**`.

That expanded form also answers the worktree-inheritance question: a linked worktree's gitdir is physically `<main>/.git/worktrees/<name>`, so once the main repo matches, every worktree of it matches too — regardless of where the worktree sits on disk.

## Verification

All behaviour demonstrated empirically in a sandbox repo (git 2.55): create-from-base, reprint-existing, existing local branch, remote-only branch (creates tracking branch via DWIM), invocation from inside a worktree, `.env` copy at root and nested while skipping `node_modules`, and work-config email applying inside sibling worktrees. The module builds and the generated script passes writeShellApplication's shellcheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)