### PR TITLE
Add CLAUDE.md for Claude Code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Nix flake configuring two machines for a single user (`aaron`):
+
+- `jimbo` — NixOS PC, `x86_64-linux`
+- `piggys-MBP` — MacBook via nix-darwin, `aarch64-darwin`
+
+## Commands
+
+```sh
+just          # rebuild + switch for the current platform (runs `git add .` first, then nh)
+just check    # nix flake check --show-trace (this is what CI runs)
+```
+
+`just` stages everything before building because flakes only see git-tracked files — new files must be at least staged or the build silently ignores them.
+
+## Architecture
+
+This flake emulates [nix-config-modules](https://github.com/chadac/nix-config-modules): instead of writing `nixosConfigurations`/`darwinConfigurations` directly, `flake.nix` runs `lib.evalModules` over `./modules` once per host and merges the results with `lib.recursiveUpdate`.
+
+Every directory under `modules/` is a config module that contributes to one or more of these options (defined in `modules/default.nix`):
+
+- `sharedSystemModule` / `sharedHomeModule` — both platforms
+- `nixosSystemModule` / `nixosHomeModule` — Linux only
+- `darwinSystemModule` / `darwinHomeModule` — macOS only
+
+`modules/default.nix` assembles these into the real `nixosConfigurations`/`darwinConfigurations` (guarded by platform, parsed from `host.system`). `modules/home/default.nix` wires the home modules into home-manager for `host.username`.
+
+**To add configuration:** create `modules/<name>/default.nix` returning an attrset with the relevant option keys above, and add `./<name>` to the `imports` list in `modules/default.nix`.
+
+Modules receive `inputs` (flake inputs) and `host` (`{ system, hostname, username }`) via `specialArgs`, in addition to the usual `pkgs`/`lib`/`config`.
+
+`nixos/` holds legacy NixOS modules imported directly by `modules/default.nix` (`nixos/system`) and `modules/home/default.nix` (`nixos/home`) — new config belongs in `modules/`, not there.
+
+### Neovim
+
+`modules/neovim/lua`, `after/`, and `lazy-lock.json` are symlinked into `~/.config/nvim` with `mkOutOfStoreSymlink`, hardcoded to the repo living at `~/workspace/jimbo`. Lua edits take effect immediately without a rebuild; only `init.lua` and the LSP/tool packages in `default.nix` require a rebuild. Lua is formatted with stylua (`stylua.toml` at repo root).
+
+### Other directories
+
+- `voyager/` — QMK keymap for a ZSA Voyager keyboard; built/flashed externally with `qmk`, not part of the flake.
+- `assets/` — static assets.


### PR DESCRIPTION
Adds a CLAUDE.md documenting the rebuild/check commands and the evalModules-based module architecture (the six shared/platform system+home module options), for use by Claude Code in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)